### PR TITLE
Use the shared MihaiBojin/renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["github>MihaiBojin/renovate"]
 }


### PR DESCRIPTION
Points this repo at the shared preset repo instead of extending `config:recommended` directly, so dependency policy lives in one place.

What the baseline adds beyond `config:recommended`:

- a 3-day minimum release age, with updates that have not aged yet hidden rather than raised as PRs that cannot merge
- vulnerability fixes exempt from that hold, plus unresolved OSV advisories on the dependency dashboard
- lock file maintenance off

Optional profiles (grouping, automerge, mise) are available but deliberately not enabled here — see the [README](https://github.com/MihaiBojin/renovate).

Validated with `renovate-config-validator` against `renovate@latest`.