### PR TITLE
Move to Python 3.11 as the floor, add 3.13 and 3.14, drop toml

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      "VARIANT": "3.12-bookworm"
+      "VARIANT": "3.14-bookworm"
     }
   },
   // Configure tool-specific properties.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install dependencies
         working-directory: .

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.14-slim
 ARG PROJECT_NAME
 ARG VERSION
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,17 @@ authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
 ]
 dynamic = ["dependencies", "optional-dependencies", "version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ] # https://pypi.org/classifiers/
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 build ==1.2.2.post1
 pre-commit ==4.1.0
 pytest ==8.3.4
-toml == 0.10.2
 twine ==6.1.0
 wheel ==0.45.1
 wheel-inspect ==1.7.2

--- a/scripts/build-docker-image.bash
+++ b/scripts/build-docker-image.bash
@@ -26,7 +26,7 @@ fi
 readonly TAG
 
 # Load project name from project manifest
-PROJECT_NAME="$(python -c "import toml; print(toml.load('$DIR/../pyproject.toml')['project']['name'])")"
+PROJECT_NAME="$(python -c "import tomllib; print(tomllib.load(open('$DIR/../pyproject.toml','rb'))['project']['name'])")"
 readonly PROJECT_NAME
 
 echo "Updating version in '$VERSION_FILE' to: $VERSION"

--- a/scripts/create-venv.bash
+++ b/scripts/create-venv.bash
@@ -15,7 +15,11 @@ if [ -d "$VENV" ]; then
 fi
 
 PYTHON=python
-if command -v python3.12 >/dev/null 2>&1; then
+if command -v python3.14 >/dev/null 2>&1; then
+    PYTHON="python3.14"
+elif command -v python3.13 >/dev/null 2>&1; then
+    PYTHON="python3.13"
+elif command -v python3.12 >/dev/null 2>&1; then
     PYTHON="python3.12"
 elif command -v python3.11 >/dev/null 2>&1; then
     PYTHON="python3.11"

--- a/scripts/functions.bash
+++ b/scripts/functions.bash
@@ -27,5 +27,5 @@ get_tag_at_head() {
 # Extracts the project name as configured in 'pyproject.toml'
 get_project_name() {
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-    python -c "import toml; print(toml.load('$dir/../pyproject.toml')['project']['name'])"
+    python -c "import tomllib; print(tomllib.load(open('$dir/../pyproject.toml','rb'))['project']['name'])"
 }

--- a/scripts/uninstall-package.bash
+++ b/scripts/uninstall-package.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ueo pipefail
 
-PROJECT_NAME=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])")
+PROJECT_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
 echo "Uninstalling $PROJECT_NAME..."
 pip uninstall -y "$PROJECT_NAME"
 echo "Done."

--- a/scripts/verify-publish.bash
+++ b/scripts/verify-publish.bash
@@ -8,7 +8,7 @@ VERSION="$(cat "$DIR"/../VERSION)"
 readonly VERSION
 
 # Load project name from project manifest
-PROJECT_NAME="$(python -c "import toml; print(toml.load('$DIR/../pyproject.toml')['project']['name'])")"
+PROJECT_NAME="$(python -c "import tomllib; print(tomllib.load(open('$DIR/../pyproject.toml','rb'))['project']['name'])")"
 readonly PROJECT_NAME
 
 # Retries a command up to 3 times


### PR DESCRIPTION
## Python versions

**3.9 reached end of life on 2025-10-31**, and the template still declared it supported and tested it on every PR. 3.10 goes EOL on 2026-10-31. Meanwhile 3.13 and 3.14 have both shipped and appeared nowhere in the template.

| | Before | After |
| --- | --- | --- |
| `requires-python` | `>=3.9` | `>=3.11` |
| classifiers | 3.9–3.12 | 3.11–3.14 |
| CI matrices (×3 workflows) | 3.9–3.12 | 3.11–3.14 |
| pinned single-version steps | 3.12 | 3.14 |
| `Dockerfile` | `python:3.13-slim` | `python:3.14-slim` |
| devcontainer | `3.12-bookworm` | `3.14-bookworm` |
| `create-venv.bash` | prefers 3.12 | prefers 3.14 |

Those last three had drifted out of sync with CI independently — the Dockerfile was already on 3.13 while CI tested 3.9 through 3.12.

## Why `tomllib` is in the same PR

It has to be. `tomllib` entered the standard library in **3.11**, so the floor bump is its prerequisite; splitting them would put a broken commit on `main`.

Four scripts shelled out to `python -c "import toml; toml.load(...)"` to read the project name from `pyproject.toml`, which is the only reason the `toml` package was a dev dependency. That package last released in **2020** and is effectively unmaintained.

```diff
-python -c "import toml; print(toml.load('pyproject.toml')['project']['name'])"
+python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])"
```

`tomllib.load` requires a binary handle, hence the `'rb'`.

## Verification

Ran the rewritten command line from `uninstall-package.bash` verbatim — it prints `template_python_package_2024`, same as before. Also swept for residual `3.9`/`3.10` references across workflows, `pyproject.toml`, `Dockerfile` and devcontainer: none left.

## Note

This does **not** bump the stale dev pins. The two open `[SECURITY]` PRs (#38, #39) should land on their own.