### PR TITLE
Declare dependencies in pyproject.toml, drop hatch-requirements-txt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ readme = { "file" = "README.md", "content-type" = "text/markdown" }
 authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
 ]
-dynamic = ["dependencies", "optional-dependencies", "version"]
+dynamic = ["version"]
+dependencies = []
 requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -21,6 +22,19 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ] # https://pypi.org/classifiers/
 
+[project.optional-dependencies]
+cli = []
+dev = [
+    # keep-sorted start
+    "build==1.5.0",
+    "pre-commit==4.6.1",
+    "pytest==9.1.1",
+    "twine==6.2.0",
+    "wheel-inspect==1.8.0",
+    "wheel==0.47.0",
+    # keep-sorted end
+]
+
 [project.urls]
 "Bug reports" = "https://github.com/MihaiBojin/template_python_package_2024/issues/new"
 "Documentation" = "https://github.com/MihaiBojin/template_python_package_2024/blob/main/python/README.md"
@@ -30,7 +44,7 @@ classifiers = [
 demo-cli = "template_cli_package.demo_cli:main"
 
 [build-system]
-requires = ["hatchling", "hatch-requirements-txt"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
@@ -58,13 +72,6 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/template_package", "src/template_cli_package"]
-
-[tool.hatch.metadata.hooks.requirements_txt]
-files = ["requirements.txt"]
-
-[tool.hatch.metadata.hooks.requirements_txt.optional-dependencies]
-cli = ["requirements-cli.txt"]
-dev = ["requirements-dev.txt"]
 
 [tool.hatch.envs.venv]
 type = "virtual"

--- a/requirements-cli.txt
+++ b/requirements-cli.txt
@@ -1,4 +1,0 @@
-# CLI requirements
-# keep-sorted start
-
-# keep-sorted end

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-# DEV requirements
-# keep-sorted start
-build ==1.5.0
-pre-commit ==4.6.1
-pytest ==9.1.1
-twine ==6.2.0
-wheel ==0.47.0
-wheel-inspect ==1.8.0
-# keep-sorted end

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-# Global requirements
-# keep-sorted start
-
-# keep-sorted end

--- a/scripts/verify-publish.bash
+++ b/scripts/verify-publish.bash
@@ -56,8 +56,14 @@ echo "Attempting to install version ($VERSION) in virtualenv ($VENV)..."
 while [[ "$#" -gt 0 ]]; do
     case $1 in
     --test)
-        echo "Installing requirements-cli from main index, since not all packages are available in test.pypi..."
-        pip install -r "$DIR"/../requirements-cli.txt
+        # The cli extras come from the main index because test.pypi does not
+        # carry every third-party package.
+        CLI_DEPS="$(python -c "import tomllib; print(' '.join(tomllib.load(open('$DIR/../pyproject.toml','rb'))['project'].get('optional-dependencies', {}).get('cli', [])))")"
+        if [ -n "$CLI_DEPS" ]; then
+            echo "Installing cli extras from main index, since not all packages are available in test.pypi..."
+            # shellcheck disable=SC2086
+            pip install $CLI_DEPS
+        fi
         echo "Attempting install: ${PROJECT_NAME}==$VERSION"
         retry pip install --index-url https://test.pypi.org/simple/ "${PROJECT_NAME}==$VERSION"
         ;;


### PR DESCRIPTION
> **Stacked on #44.** Base is `modernize-python-versions`, so the diff stays clean; GitHub will retarget to `main` once #44 merges. Merge #44 first.

## The problem

Dependencies lived in three `requirements*.txt` files that `hatch-requirements-txt` imported into package metadata at build time. Two issues:

**It is a maintenance risk in the build path.** That plugin last released **2024-01-24** — single purpose, single maintainer. If it breaks against a future hatchling, the package stops building.

**The indirection runs backwards.** PEP 621 puts dependencies in `[project]`. The template instead made `requirements.txt` the source and used a plugin to pull it into metadata. In 2024 that kept `pip install -r` workflows working; it buys little now.

## The change

```diff
-dynamic = ["dependencies", "optional-dependencies", "version"]
+dynamic = ["version"]
+dependencies = []
+
+[project.optional-dependencies]
+cli = []
+dev = [ ... six pins ... ]

-requires = ["hatchling", "hatch-requirements-txt"]
+requires = ["hatchling"]
```

Plus deletion of the three `requirements*.txt` files and the `[tool.hatch.metadata.hooks.requirements_txt]` sections. `version` stays dynamic — it still comes from the `VERSION` file.

## The one non-obvious consumer

`verify-publish.bash` read `requirements-cli.txt` directly to install cli extras from the main index during test.pypi verification (test.pypi does not mirror every third-party package). It now reads the same list from `pyproject.toml`, and skips the install when the list is empty — which it is today, so this is a no-op in practice but stays correct once someone adds a cli dependency.

## Verification

Built a wheel with **hatchling alone** and inspected `METADATA`:

```
Requires-Python: >=3.11
Provides-Extra: cli
Provides-Extra: dev
Requires-Dist: build==1.2.2.post1; extra == 'dev'
... all six dev pins, each tagged extra == 'dev'
```

Both extras survive, every pin is preserved. `shellcheck` clean on the modified script.

## Note on Renovate

Dependency updates move from the `pip_requirements` manager to `pep621`. Both resolve through the `pypi` datasource, so the `group-python-tooling` profile (added in #41) keeps matching without change.