### PR TITLE
Drop 2024 from the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
-# Python Package template - 2024
+# Python Package template
 
-![Build Status](https://github.com/MihaiBojin/template-python-package-2024/actions/workflows/python-tests.yml/badge.svg)
-[![PyPI version](https://badge.fury.io/py/template-python-package-2024.svg)](https://badge.fury.io/py/template-python-package-2024)
-[![Python Versions](https://img.shields.io/pypi/pyversions/template-python-package-2024.svg)](https://pypi.org/project/template-python-package-2024/)
-[![License](https://img.shields.io/github/license/MihaiBojin/template-python-package-2024.svg)](LICENSE)
+![Build Status](https://github.com/MihaiBojin/template-python-package/actions/workflows/python-tests.yml/badge.svg)
+[![License](https://img.shields.io/github/license/MihaiBojin/template-python-package.svg)](LICENSE)
 
 Use this repo as a template for starting multi-package Python projects.
 
 ## Quickstart
 
-The project is published to <https://pypi.org/project/template-python-package-2024/>.
-Install it via:
+Press **Use this template** on GitHub, or clone it:
 
 ```shell
-pip install template-python-package-2024
-
-# or alternatively, directly from git
-pip install "git+https://github.com/MihaiBojin/template-python-package-2024@main"
+git clone https://github.com/MihaiBojin/template-python-package.git my-project
 ```
+
+Then claim the name as your own: `name` and `[project.urls]` in
+`pyproject.toml`, the package directories under `src/`, and the entry point
+under `[project.scripts]`.
+
+This template is not published to PyPI, and it is not meant to be. Nobody
+installs a template; you copy it. Note that `template-python-package` on PyPI
+is an unrelated project by another author, so choose your own name before you
+publish anything. The publish workflow stays disabled (`if: false`) until you
+do.
 
 ## Publishing to PyPI
 
@@ -31,7 +35,7 @@ git tag v0.1.x
 git push origin v0.1.x
 ```
 
-A [GitHub Action](https://github.com/MihaiBojin/template-python-package-2024/actions) will run, build the library and publish it to PyPI.
+A [GitHub Action](https://github.com/MihaiBojin/template-python-package/actions) will run, build the library and publish it to PyPI.
 
 ### Manual
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
-name = 'template_python_package_2024'
+name = 'template_python_package'
 license = "Apache-2.0"
 description = "A starter template for Python packages."
-keywords = ["python", "package", "template", "2024"]
+keywords = ["python", "package", "template", "starter"]
 readme = { "file" = "README.md", "content-type" = "text/markdown" }
 authors = [
     { name = "Mihai Bojin", email = "557584+MihaiBojin@users.noreply.github.com" },
@@ -22,9 +22,9 @@ classifiers = [
 ] # https://pypi.org/classifiers/
 
 [project.urls]
-"Bug reports" = "https://github.com/MihaiBojin/template_python_package_2024/issues/new"
-"Documentation" = "https://github.com/MihaiBojin/template_python_package_2024/blob/main/python/README.md"
-"Source" = "https://github.com/MihaiBojin/template_python_package_2024"
+"Bug reports" = "https://github.com/MihaiBojin/template-python-package/issues/new"
+"Documentation" = "https://github.com/MihaiBojin/template-python-package/blob/main/README.md"
+"Source" = "https://github.com/MihaiBojin/template-python-package"
 
 [project.scripts]
 demo-cli = "template_cli_package.demo_cli:main"


### PR DESCRIPTION
The repo is now **[MihaiBojin/template-python-package](https://github.com/MihaiBojin/template-python-package)** — already renamed, and GitHub redirects the old URL. This updates the references inside the repo.

| | Before | After |
| --- | --- | --- |
| package `name` | `template_python_package_2024` | `template_python_package` |
| `keywords` | `[..., "2024"]` | `[..., "starter"]` |
| `[project.urls]` ×3 | `..._2024`, underscored | fixed, all resolve |
| README title, badges, links | `-2024` | updated |

## The part worth reading

Renaming surfaced a live hazard. The README's PyPI badges and `pip install` line pointed at `template-python-package-2024`, which **does not exist on PyPI** — so they harmlessly 404'd. Rewritten naively to drop the suffix, they resolve to [`template-python-package`](https://pypi.org/project/template-python-package/), **a real and unrelated project by another author**.

Anyone following the quickstart would have installed a stranger's package. The mechanical rename would have turned a dead link into a live wrong one.

So:

- **Both PyPI badges removed** — they rendered another project's version and Python support
- **Quickstart rewritten** around what this actually is: a GitHub template you copy (the repo is correctly flagged `is_template`), not a package you install
- States explicitly that the PyPI name belongs to someone else, and that you must choose your own before publishing

This also corrects a claim that was already false: the README asserted "The project is published to pypi.org/..." when it never has been, and the publish job is `if: false`.

## Drive-by URL fixes

`[project.urls]` was broken before this PR — it spelled the repo with **underscores** (`template_python_package_2024`), which GitHub does not resolve, and the documentation link pointed into a `python/` directory that does not exist. All three now return 200, verified.

## Naming

Package name matches the repo. It is never published, so the PyPI collision is theoretical — and a template that forces you to rename before publishing is arguably behaving correctly.

## Note

Open PRs #45 and #49 predate the rename. GitHub keeps them attached; #45 touches `pyproject.toml`, so expect a trivial conflict on the `name` line depending on merge order.