### PR TITLE
Wire up PyPI Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,9 +37,16 @@ jobs:
         working-directory: .
         run: uv run pytest tests
 
-  publish:
-    # disable the workflow by default
-    # uncomment when ready to publish to PyPI
+  # Publishing uses PyPI Trusted Publishing (OIDC): no tokens, no secrets.
+  # It requires one-time setup on PyPI and test.PyPI before it can work --
+  # see "Enabling the publish workflow" in the README.
+  #
+  # Build once, then publish the same artifacts to both indexes. The jobs are
+  # split because a job may declare only one `environment`, and each index is
+  # a separate deployment target with its own trusted publisher.
+  build:
+    # The publish flow is disabled until the README setup is done.
+    # Delete this line to enable it; the jobs below are gated through `needs`.
     if: false
 
     needs: lint-test
@@ -62,17 +69,81 @@ jobs:
         working-directory: .
         run: uv build
 
+      - name: Upload distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-test:
+    needs: build
+    runs-on: ubuntu-latest
+    # The environment name is part of what PyPI verifies, so it has to match
+    # the trusted publisher registered on test.pypi.org.
+    environment:
+      name: testpypi
+    permissions:
+      # Mint the OIDC token uv exchanges for an upload token
+      id-token: write
+      contents: read
+    steps:
+      # Needed for the [[tool.uv.index]] definition of `testpypi`
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+
+      # `always` rather than the default `automatic`: fail loudly if the OIDC
+      # setup is broken, instead of falling back to an anonymous upload.
       - name: Publish package to test repository
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TESTPYPI_PASSWORD }}
         working-directory: .
-        run: uv publish --index testpypi
+        run: uv publish --index testpypi --trusted-publishing always
+
+  publish:
+    needs: publish-test
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          python-version: "3.14"
+          enable-cache: true
+
+      # Run before anything writes to the working tree: the script refuses to
+      # run on a dirty checkout. verify-publish.bash reads the VERSION file to
+      # decide which release to install.
+      - name: Set the correct (tag) version
+        working-directory: .
+        run: scripts/detect-and-set-tag-version.bash
+
+      - name: Download distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
 
       - name: Publish package
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASSWORD }}
         working-directory: .
-        run: uv publish
+        run: uv publish --trusted-publishing always
 
       - name: Waiting 30 seconds for the PyPI indexes to be updated
         run: sleep 30

--- a/README.md
+++ b/README.md
@@ -48,13 +48,59 @@ This template is not published to PyPI, and it is not meant to be. Nobody
 installs a template; you copy it. Note that `template-python-package` on PyPI
 is an unrelated project by another author, so choose your own name before you
 publish anything. The publish workflow stays disabled (`if: false`) until you
-do.
+work through [Enabling the publish workflow](#enabling-the-publish-workflow).
 
 ## Publishing to PyPI
 
+### Enabling the publish workflow
+
+`python-publish.yml` is written for [PyPI Trusted
+Publishing](https://docs.pypi.org/trusted-publishers/): GitHub mints a
+short-lived OIDC token that PyPI exchanges for an upload token. There is no
+API token to create, store or rotate, and no secret in the repository.
+
+It is wired up but deliberately switched off, because it cannot work until
+you have done the four steps below. Nothing here has been exercised against a
+live index.
+
+**1. Claim a project name you own.** A trusted publisher binds a PyPI project
+name to this repository, so you cannot register one for a name someone else
+holds. Rename `name` in `pyproject.toml` first (see the Quickstart).
+
+**2. Register a pending publisher, once on each index.** PyPI and TestPyPI are
+separate registries with separate accounts, so do this twice:
+[pypi.org](https://pypi.org/manage/account/publishing/) and
+[test.pypi.org](https://test.pypi.org/manage/account/publishing/). Both live
+under the account sidebar's *Publishing* page — the project sidebar only
+offers this for projects that already exist. Choose GitHub Actions and fill
+in:
+
+| Field | Value |
+| --- | --- |
+| PyPI project name | your `project.name` from `pyproject.toml` |
+| Owner | your GitHub user or org |
+| Repository name | this repository |
+| Workflow name | `python-publish.yml` (filename only, not a path) |
+| Environment name | `pypi` on PyPI, `testpypi` on TestPyPI |
+
+A pending publisher does **not** reserve the name; if someone else registers
+it before your first upload, yours is invalidated. On first successful
+publish it converts to a normal publisher.
+
+**3. Create the two GitHub environments.** Under *Settings → Environments*,
+add `pypi` and `testpypi`. The names have to match what you registered above,
+because PyPI verifies the environment as part of the OIDC claim. This is also
+where you would add required reviewers, if you want a human gate before a
+release goes out.
+
+**4. Enable the workflow.** Delete the `if: false` line from the `build` job
+in `.github/workflows/python-publish.yml`. The `publish-test` and `publish`
+jobs are chained to it through `needs`, so that one line gates all three.
+
 ### GitHub-based version publishing
 
-The simplest way to publish a new version (if you have committer rights) is to tag a commit and push it to the repo:
+Once the above is done, publishing a new version (if you have committer
+rights) is a tag push:
 
 ```shell
 # At a certain commit, ideally after merging a PR to main
@@ -62,11 +108,15 @@ git tag v0.1.x
 git push origin v0.1.x
 ```
 
-A [GitHub Action](https://github.com/MihaiBojin/template-python-package/actions) will run, build the library and publish it to PyPI.
+A [GitHub Action](https://github.com/MihaiBojin/template-python-package/actions)
+builds the distributions once, publishes them to TestPyPI, then to PyPI, and
+finally installs the released version from PyPI to verify it works.
 
 ### Manual
 
-These steps can also be performed locally. For these commands to work, you will need to export two environment variables:
+These steps can also be performed locally. Trusted Publishing only exists
+inside GitHub Actions, so local publishing still uses API tokens. Export two
+environment variables:
 
 ```shell
 export TESTPYPI_PASSWORD=... # token for https://test.pypi.org/legacy/


### PR DESCRIPTION
Follow-up to #54, which left this as the obvious next step.

Replaces the two API tokens in the publish workflow with OIDC. GitHub mints a short-lived token that PyPI exchanges for an upload token, so there is nothing to store or rotate — `TESTPYPI_PASSWORD` and `PYPI_PASSWORD` are no longer referenced by any workflow, and the secrets can be deleted from repo settings.

## Set up, deliberately not working

**This cannot be exercised from this repository, and I have not tried.** A trusted publisher binds a *PyPI project name* to a repo, and `template-python-package` on PyPI is version 0.1.1 by Umesh Timalsina — unrelated to this project. There is no name here to register against.

That is the correct end state for a template: the plumbing is in place and documented, and the person who copies it does the four remaining steps under their own name. The flow stays behind `if: false`, exactly as before this PR.

## Workflow shape

`publish` becomes `build → publish-test → publish`.

The split is forced: a job may declare only one `environment`, and each index is a separate deployment target with its own trusted publisher, so TestPyPI and PyPI cannot share a job. It also means the distributions are built once and the *same* artifacts reach both indexes, instead of being rebuilt per target.

```
build          if: false, needs lint-test      → uploads dist/ artifact
publish-test   environment: testpypi           → uv publish --index testpypi
publish        environment: pypi               → uv publish, then verify
```

Details worth a reviewer's eye:

- `permissions: id-token: write` on both publish jobs — this is what allows the OIDC token to be minted. `contents: read` is there because declaring `permissions` at all drops everything not listed, and checkout needs it.
- `--trusted-publishing always` rather than the default `automatic`. `automatic` silently falls back when it cannot find an OIDC token; `always` fails the job.
- Both publish jobs still check out the repo. `publish-test` needs it for the `[[tool.uv.index]]` definition of `testpypi`; `publish` needs it for `verify-publish.bash`.
- `publish` re-runs `detect-and-set-tag-version.bash`, since `verify-publish.bash` reads `VERSION` to decide which release to install, and a fresh checkout has the repo value rather than the tag. It runs before the artifact download, because the script refuses a dirty tree.
- The `if: false` gate moved to `build`; the other two are chained through `needs`, so one line still gates all three.

## README

New "Enabling the publish workflow" section documents the four steps: claim a PyPI name you own, register a pending publisher on **both** pypi.org and test.pypi.org (they are separate registries — with the exact form fields tabulated), create the matching `pypi` and `testpypi` GitHub environments, then delete the gate.

It also records two things that are easy to get wrong: a pending publisher does not reserve the name, and the environment name is part of what PyPI verifies, so it must match on both sides.

The "Manual" section now says plainly that local publishing still uses tokens, because Trusted Publishing only exists inside Actions. `make publish` is unchanged.

## Verification

Static only, which is all that is possible here:

- `actionlint` clean on the new jobs; the sole finding is the intentional `if: false` (docker-publish.yml has the same pre-existing one)
- Parsed the workflow to confirm the job graph, the two environments, the `id-token: write` permissions, and that no `secrets.*` reference or `UV_PUBLISH_TOKEN` survives anywhere in the file
- Every action ref resolves to a real tag — `setup-uv@v9.0.0`, `upload-artifact@v7`, `download-artifact@v8`, `checkout@v7`. Checked deliberately: #54 shipped `setup-uv@v9` on the assumption a floating major existed, and it does not
- All 12 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)