### PR TITLE
Fix two broken steps in the publish flow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -51,6 +51,11 @@ jobs:
   # Built once and handed to both publish jobs, so the artifact uploaded to
   # PyPI is byte-for-byte the one that went to TestPyPI.
   build:
+    # Publishing is off in the template itself, which has nothing to release.
+    # Delete this line to enable it: publish-test and publish are chained to
+    # this job through `needs`, so one line gates all three.
+    if: false
+
     needs: lint-test
     runs-on: ubuntu-latest
     steps:
@@ -79,10 +84,6 @@ jobs:
           if-no-files-found: error
 
   publish-test:
-    # Publishing is off in the template itself, which has nothing to release.
-    # Delete this line in your project once the trusted publisher is registered.
-    if: false
-
     needs: build
     runs-on: ubuntu-latest
     # Binds this job to the trusted publisher registered for `testpypi`.
@@ -93,10 +94,16 @@ jobs:
       id-token: write
       contents: read
     steps:
+      # `--index testpypi` resolves that name from [[tool.uv.index]] in
+      # pyproject.toml, which is not part of the built artifact.
+      - name: Checkout code
+        uses: actions/checkout@v7
+
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
+          enable-cache: true
 
       - name: Download distributions
         uses: actions/download-artifact@v8
@@ -110,10 +117,6 @@ jobs:
         run: uv publish --index testpypi --trusted-publishing always
 
   publish:
-    # Publishing is off in the template itself, which has nothing to release.
-    # Delete this line in your project once the trusted publisher is registered.
-    if: false
-
     needs: publish-test
     runs-on: ubuntu-latest
     # Binds this job to the trusted publisher registered for `pypi`. Add a
@@ -131,6 +134,14 @@ jobs:
         uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
+          enable-cache: true
+
+      # verify-publish.bash reads VERSION to decide which release to install,
+      # and a fresh checkout still holds the committed placeholder. Run it
+      # before anything else touches the tree: the script refuses a dirty one.
+      - name: Set the correct (tag) version
+        working-directory: .
+        run: scripts/detect-and-set-tag-version.bash
 
       - name: Download distributions
         uses: actions/download-artifact@v8

--- a/README.md
+++ b/README.md
@@ -62,25 +62,31 @@ deleted line.
    PyPI first. `template_python_package` is taken by an unrelated project, so
    leaving the template's name in place will fail.
 
-2. **Register a trusted publisher** on PyPI, under the project's *Publishing*
-   settings. For a project that does not exist yet, use the *pending publisher*
-   flow.
+2. **Register a pending publisher, once on each index.** PyPI and TestPyPI are
+   separate registries with separate accounts, so do this twice:
+   [pypi.org](https://pypi.org/manage/account/publishing/) and
+   [test.pypi.org](https://test.pypi.org/manage/account/publishing/). Both live
+   under the *account* sidebar's Publishing page — the project sidebar only
+   offers this for projects that already exist.
 
    | Field | Value |
    | --- | --- |
    | Owner | your GitHub user or org |
    | Repository | your repository name |
-   | Workflow | `python-publish.yml` |
-   | Environment | `pypi` |
+   | Workflow | `python-publish.yml` (filename only, not a path) |
+   | Environment | `pypi` on PyPI, `testpypi` on TestPyPI |
 
-   Repeat on [test.pypi.org](https://test.pypi.org) with environment `testpypi`.
+   A pending publisher does **not** reserve the name. If someone else registers
+   it before your first upload, yours is invalidated. On the first successful
+   publish it converts to a normal publisher.
 
 3. **Create the GitHub environments** `pypi` and `testpypi` under *Settings →
    Environments*. Add a required reviewer on `pypi` if you want a human gate
    before anything reaches the real index.
 
-4. **Enable publishing** by deleting the `if: false` line from the
-   `publish-test` and `publish` jobs in `.github/workflows/python-publish.yml`.
+4. **Enable publishing** by deleting the `if: false` line from the `build` job
+   in `.github/workflows/python-publish.yml`. The `publish-test` and `publish`
+   jobs are chained to it through `needs`, so that one line gates all three.
 
 No API tokens, and nothing to store in repository secrets. GitHub mints a
 short-lived OIDC token per run and PyPI exchanges it for a scoped credential.


### PR DESCRIPTION
Adopts the parts of #56 worth keeping. #56 implemented Trusted Publishing in parallel with #55 and got **two things right that #55 did not** — both real bugs, both mine.

## The two fixes

**`publish-test` had no checkout.** `uv publish --index testpypi` resolves that index name from `[[tool.uv.index]]` in `pyproject.toml`, and `pyproject.toml` is not part of the built artifact. The job had nothing to resolve the index against.

**The `publish` job never set the tag version.** `verify-publish.bash` reads the `VERSION` file to decide which release to install (`scripts/verify-publish.bash:7`), and a fresh checkout still holds the committed placeholder. The final verification step would have looked for `0.0.0` instead of the version just published.

Neither would ever have surfaced here, because publishing is gated off in the template. They would have failed in the first project that switched it on — the worst possible place to find them.

## Also adopted

**One gate instead of two.** `if: false` moves to the `build` job; `publish-test` and `publish` are chained to it through `needs`. Enabling publishing is now one deleted line rather than two, and there is no way to half-enable it.

**`enable-cache: true`** on the publish jobs' `setup-uv`, which #55 dropped.

**README setup detail** #56 documented and #55 missed: pending publishers are registered per index under the *account* sidebar (the project sidebar only offers it for projects that already exist), the Workflow field wants a bare filename rather than a path, and a pending publisher does **not** reserve the name — if someone registers it first, yours is invalidated.

## Not adopted

#56 branched before #55 merged, so it does not carry #55's cleanups: `.pypirc` removal, the matching `pyproject.toml` exclude entry, and the Makefile simplification to uv's own `UV_PUBLISH_TOKEN` instead of mapping two project-specific variables onto it. Those stay as they are on `main`.

I also did not adopt #56's stated reason for the step ordering. It says the version script must run first because downloading artifacts dirties the tree — but `dist/` is gitignored (`.gitignore:64`) and `is_dirty` uses `git status --porcelain`, so it would not. The ordering is still correct and defensive, just for a different reason, and the comment says so.

## Verification

Parsed the workflow YAML to confirm the job graph and step order, and `pre-commit run --all-files` passes all twelve hooks.

Closes #56.