### PR TITLE
Restore the python-tooling Renovate preset; document the sdist .gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ build-backend = "hatchling.build"
 # Directories must use the '/**' form. A bare directory name loses to a
 # re-inclusion in .gitignore -- '!.vscode/settings.json' there was enough to
 # pull .vscode into the sdist despite a '.vscode' entry here.
+#
+# .gitignore is deliberately absent from this list: hatchling force-includes
+# every VCS exclusion file into the sdist (builders/sdist.py, in
+# get_default_build_data), and force_include bypasses these patterns. Neither
+# an entry here nor 'ignore-vcs = true' removes it. That is by design -- the
+# sdist must build the same file set the source tree did, and hatchling reads
+# .gitignore to decide that set.
 exclude = [
     # keep-sorted start
     ".devcontainer/**",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "github>MihaiBojin/renovate",
     "github>MihaiBojin/renovate:group-github-actions",
+    "github>MihaiBojin/renovate:group-python-tooling",
     "github>MihaiBojin/renovate:pre-commit"
   ]
 }


### PR DESCRIPTION
Two pieces of housekeeping left over from #54.

## Renovate preset

The `group-python-tooling` import came out in #54 because the preset still listed `build`, `twine`, `wheel` and `toml` — none of which survive the uv migration. The preset has been corrected upstream in **[MihaiBojin/renovate#3](https://github.com/MihaiBojin/renovate/pull/3)**, so the import earns its place again: `pre-commit`, `pytest` and `wheel-inspect` travel in one PR instead of three.

**Merge the upstream PR first.** Renovate resolves presets at run time, so landing this one first just means the next run groups against the old list for a while — inert, since the retired entries match nothing here, but pointless.

Placement is unconstrained: the preset repo's README requires `group-python-tooling` to come after `group-non-major` when they are composed together, and this repo does not extend `group-non-major`.

## The .gitignore in every sdist

Flagged as a loose end in #54. It turns out not to be fixable through configuration, and the reason is worth writing down.

`hatchling/builders/sdist.py`, in `get_default_build_data`:

```python
for exclusion_files in self.config.vcs_exclusion_files.values():
    for exclusion_file in exclusion_files:
        force_include[exclusion_file] = os.path.basename(exclusion_file)
```

`.gitignore` is routed through `force_include`, which bypasses the `exclude` patterns entirely. I confirmed in an isolated throwaway package that neither `exclude = [".gitignore"]` nor `ignore-vcs = true` removes it.

That is deliberate rather than a bug: hatchling reads `.gitignore` to decide which files to collect, so an sdist stripped of it would build a *different* file set than the source tree did.

So there is no fix, only a fact. This PR records it as a comment next to the `exclude` list — where the next person will go looking — instead of leaving a standing question, or worse, a no-op config line implying it works.

## Verification

- All 12 pre-commit hooks pass, `check-json5` included
- `renovate.json` re-checked against the schema shape used by the other imports
- Confirmed empirically that the exclude entry was a no-op before removing it again

🤖 Generated with [Claude Code](https://claude.com/claude-code)