### PR TITLE
Add a Helm chart and release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@
 .venv
 .vscode
 build/
+charts/
 dist/
+out/
 venv/
 # keep-sorted end

--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -1,0 +1,81 @@
+name: Publish Helm Chart
+
+on:
+  # Trigger only on v0.* tag pushes
+  push:
+    tags:
+      - "v0.*"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      - name: Lint chart
+        run: helm lint charts/*
+
+      - name: Render chart
+        run: helm template release-test charts/*
+
+  publish:
+    # The chart release is disabled until the gh-pages branch exists and Pages
+    # is serving from it -- see "Publishing the Helm chart" in the README.
+    # Delete this line to enable it.
+    if: false
+
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      # chart-releaser pushes the packaged chart and the updated index
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # chart-releaser diffs against the previous chart tag, so it needs
+          # the full history rather than a shallow clone
+          fetch-depth: 0
+
+      - name: Set chart version
+        run: scripts/helm-set-version.bash
+
+      - name: Configure git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # chart-releaser decides what to publish by diffing *tracked* files under
+      # charts/ against the previous chart tag. Chart.yaml is tracked at 0.0.0
+      # and rewritten above, so without committing that rewrite the diff is
+      # empty and the release is silently skipped. The commit stays local to
+      # this job and is never pushed.
+      - name: Commit the generated chart version
+        run: |
+          git add charts
+          git commit -m "Set chart version for ${GITHUB_REF_NAME}"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.1
+
+      - name: Run chart-releaser
+        id: chart_releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          skip_existing: true
+
+      # chart-releaser exits 0 when it finds nothing to do, so a no-op is
+      # indistinguishable from a success. On a tag build it must publish.
+      - name: Verify the chart was published
+        run: |
+          if [ -z "${{ steps.chart_releaser.outputs.changed_charts }}" ]; then
+            echo "ERROR: chart-releaser published nothing on a tag build" >&2
+            exit 1
+          fi
+          echo "Published ${{ steps.chart_releaser.outputs.changed_charts }} version ${{ steps.chart_releaser.outputs.chart_version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+out/
 parts/
 sdist/
 var/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,11 @@ repos:
       # keep-sorted start
       - id: check-ast
       - id: check-docstring-first
+      # Helm templates are Go templates, not YAML, until helm renders them.
+      # Chart.yaml and values.yaml are still checked; `make helm-lint` covers
+      # the templates.
       - id: check-yaml
+        exclude: ^charts/[^/]+/templates/
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,24 @@ docker-run:
 	@echo "Running Docker image..."
 	@scripts/run-docker-image.bash $(ARGS)
 
+.PHONY: helm-lint
+helm-lint:
+	@echo "Linting the Helm chart..."
+	@helm lint charts/*
+	@echo "Rendering the Helm chart..."
+	@helm template release-test charts/* >/dev/null
+	@echo "OK."
+
+.PHONY: helm-set-version
+helm-set-version:
+	@scripts/helm-set-version.bash
+
+.PHONY: helm-package
+helm-package: helm-lint
+	@echo "Packaging the Helm chart..."
+	@rm -rf out/charts
+	@helm package charts/* -d out/charts
+
 .PHONY: publish-test
 publish-test: build
 	@echo "Publishing to test repo..."

--- a/README.md
+++ b/README.md
@@ -109,3 +109,70 @@ make docker-run
 # or
 make docker-run ARGS="--arg1 --arg2 --etc"
 ```
+
+## Publishing the Helm chart
+
+`charts/` holds a chart that deploys the image built above. See
+[its README](charts/template-python-package/README.md) for values and
+install instructions.
+
+Locally:
+
+```shell
+make helm-lint     # lint and render
+make helm-package  # package into out/charts/
+```
+
+Releases are handled by `helm-publish.yml` on a `v0.*` tag, using
+[chart-releaser](https://github.com/helm/chart-releaser-action), which
+publishes the packaged chart to a GitHub release and serves the index from
+the `gh-pages` branch.
+
+### Enabling the chart release
+
+Like the PyPI workflow, this is wired up but switched off, because it needs
+one-time setup that cannot be done from a commit.
+
+**1. Create the `gh-pages` branch.** chart-releaser publishes `index.yaml`
+there; it must exist before the first run.
+
+```shell
+git checkout --orphan gh-pages
+git rm -rf .
+echo "Helm charts" > index.html
+git add index.html
+git commit -m "Init gh-pages"
+git push origin gh-pages
+git checkout main
+rm -f index.html
+```
+
+**2. Serve it.** *Settings → Pages*, deploy from branch `gh-pages`, folder
+`/ (root)`. The chart's `home` URL in `Chart.yaml` points at the resulting
+Pages site, so update it when you rename the project.
+
+**3. Enable the workflow.** Delete the `if: false` line from the `publish`
+job in `.github/workflows/helm-publish.yml`. The `lint` job runs regardless.
+
+Once live, consumers add the repo with:
+
+```shell
+helm repo add template-python-package https://MihaiBojin.github.io/template-python-package/
+```
+
+### How the version reaches the chart
+
+Worth understanding before changing any of it, because the failure is silent.
+
+`Chart.yaml` is tracked at `0.0.0` and rewritten from the git tag at release
+time by `scripts/helm-set-version.bash`. chart-releaser decides what to
+publish by diffing **tracked** files under `charts/` against the previous
+chart tag, so the workflow commits that rewrite before invoking it. The commit
+is local to the CI job and never pushed. Without it, the diff is empty,
+chart-releaser finds nothing to do, exits 0, and the release is skipped while
+the build stays green — which is why the workflow also fails explicitly when
+nothing was published on a tag build.
+
+The `v` prefix is stripped from the tag as well: Helm chart versions are
+SemVer without one, and published artifacts are named
+`template-python-package-0.1.0.tgz`.

--- a/charts/template-python-package/.helmignore
+++ b/charts/template-python-package/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/template-python-package/Chart.yaml
+++ b/charts/template-python-package/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: template-python-package
+description: A Helm chart for the template-python-package demo CLI
+type: application
+
+# Tracked at 0.0.0, exactly like the VERSION file: the real number comes from
+# the git tag at release time, written in by scripts/helm-set-version.bash.
+# Do not bump these by hand.
+version: "0.0.0"
+appVersion: "0.0.0"
+
+maintainers:
+  - name: Mihai Bojin
+    email: mihai.bojin@gmail.com
+
+annotations:
+  category: Application
+  licenses: Apache-2.0
+
+keywords:
+  - python
+  - package
+  - template
+  - starter
+
+home: https://MihaiBojin.github.io/template-python-package/
+sources:
+  - https://github.com/MihaiBojin/template-python-package

--- a/charts/template-python-package/README.md
+++ b/charts/template-python-package/README.md
@@ -1,0 +1,61 @@
+# template-python-package Helm chart
+
+Deploys the container image built by this repository. Rename the directory and
+the `name` in `Chart.yaml` when you claim the template as your own — the
+scripts locate the chart by globbing `charts/*`, so nothing else needs editing.
+
+## Install
+
+```shell
+helm install my-release charts/template-python-package
+```
+
+The chart creates its own namespace, named after the chart. Set
+`namespaceOverride` to deploy somewhere else.
+
+## Versioning
+
+`version` and `appVersion` are tracked at `0.0.0`, the same placeholder
+convention the `VERSION` file uses. The real number is written in at release
+time by `scripts/helm-set-version.bash`, from the git tag, with the leading
+`v` stripped. Do not bump them by hand.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Deployment replicas |
+| `image.repository` | `ghcr.io/mihaibojin/template-python-package` | Image to run |
+| `image.tag` | `""` | Defaults to `.Chart.AppVersion` |
+| `image.pullPolicy` | `Always` | |
+| `command` / `args` | `[]` | Override the image entrypoint |
+| `config` | `{LOG_LEVEL: INFO}` | Rendered into a ConfigMap, injected via `envFrom` |
+| `secrets` | `{}` | Rendered into a Secret, injected via `envFrom` |
+| `namespaceOverride` | `""` | Deploy into a namespace other than the chart name |
+| `podSecurityContext` | runs as uid/gid 30000 | |
+| `securityContext` | non-root, no privilege escalation, read-only rootfs, all caps dropped | |
+| `resources.requests` | `100m` CPU, `128Mi` memory | |
+
+Both `config` and `secrets` are free-form maps: every key becomes an
+environment variable. Never commit real secret values — pass them with
+`--set-string` or an unversioned values file.
+
+## A note on the default workload
+
+The bundled demo CLI prints one line and exits, so the Deployment restarts it
+forever. That is deliberate for a template: it proves the image is wired up
+without pretending to be a real service. Point `command`/`args` at a
+long-running process, or swap the Deployment for a `CronJob`, once there is
+something real to run.
+
+## Tests
+
+```shell
+helm test my-release
+```
+
+The test runs the application image once and asserts a clean exit, which
+proves the image is pullable, the tag resolves and the entrypoint works. It
+deliberately does not assert "the Deployment's pod is Running" — that needs
+`kubectl` in the test image plus RBAC to list pods, and a test that cannot
+pass is worse than no test.

--- a/charts/template-python-package/templates/_helpers.tpl
+++ b/charts/template-python-package/templates/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "template-python-package.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "template-python-package.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The namespace every resource in this chart is created in.
+*/}}
+{{- define "template-python-package.namespace" -}}
+{{- default (include "template-python-package.name" .) .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "template-python-package.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "template-python-package.labels" -}}
+helm.sh/chart: {{ include "template-python-package.chart" . }}
+{{ include "template-python-package.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "template-python-package.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "template-python-package.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/template-python-package/templates/configmap.yaml
+++ b/charts/template-python-package/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "template-python-package.name" . }}
+  namespace: {{ include "template-python-package.namespace" . }}
+  labels:
+    {{- include "template-python-package.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/template-python-package/templates/deployment.yaml
+++ b/charts/template-python-package/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "template-python-package.name" . }}
+  namespace: {{ include "template-python-package.namespace" . }}
+  labels:
+    {{- include "template-python-package.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "template-python-package.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{/*
+      Roll the pods when the ConfigMap or Secret contents change; without
+      this, `helm upgrade` updates the objects but leaves the running
+      container holding the old environment.
+      */}}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "template-python-package.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          envFrom:
+            {{- if .Values.config }}
+            - configMapRef:
+                name: {{ include "template-python-package.name" . }}
+            {{- end }}
+            {{- if .Values.secrets }}
+            - secretRef:
+                name: {{ include "template-python-package.name" . }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/template-python-package/templates/namespace.yaml
+++ b/charts/template-python-package/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "template-python-package.namespace" . }}
+  labels:
+    {{- include "template-python-package.labels" . | nindent 4 }}

--- a/charts/template-python-package/templates/secrets.yaml
+++ b/charts/template-python-package/templates/secrets.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "template-python-package.name" . }}
+  namespace: {{ include "template-python-package.namespace" . }}
+  labels:
+    {{- include "template-python-package.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/template-python-package/templates/tests/test-pod-running.yaml
+++ b/charts/template-python-package/templates/tests/test-pod-running.yaml
@@ -1,0 +1,49 @@
+{{/*
+Runs the application image once and asserts it exits cleanly, which proves the
+image is pullable, the tag resolves and the entrypoint works.
+
+Deliberately not "check that the Deployment's pod is Running": that needs
+kubectl in the test image and RBAC to list pods, neither of which a default
+ServiceAccount has. A test that cannot pass is worse than no test.
+*/}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "template-python-package.fullname" . }}-test-entrypoint"
+  namespace: {{ include "template-python-package.namespace" . }}
+  labels:
+    {{- include "template-python-package.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: test-entrypoint
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      {{- with .Values.command }}
+      command:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.args }}
+      args:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      envFrom:
+        {{- if .Values.config }}
+        - configMapRef:
+            name: {{ include "template-python-package.name" . }}
+        {{- end }}
+        {{- if .Values.secrets }}
+        - secretRef:
+            name: {{ include "template-python-package.name" . }}
+        {{- end }}

--- a/charts/template-python-package/values.yaml
+++ b/charts/template-python-package/values.yaml
@@ -1,0 +1,75 @@
+replicaCount: 1
+
+image:
+  # The docker-publish workflow pushes to ghcr.io/<owner>/<repo>, lowercased
+  repository: ghcr.io/mihaibojin/template-python-package
+  pullPolicy: Always
+  # Defaults to .Chart.AppVersion, which the release sets from the git tag
+  tag: ""
+
+# The bundled demo CLI prints one line and exits, so the default Deployment
+# restarts it forever. That is fine for a template -- it proves the image is
+# wired up -- but a real project overrides these with a long-running command.
+# Leave both empty to use the image's ENTRYPOINT.
+command: []
+args: []
+
+# Non-sensitive configuration, rendered into a ConfigMap and exposed to the
+# container as environment variables.
+config:
+  LOG_LEVEL: "INFO"
+
+# Sensitive configuration, rendered into a Secret and exposed the same way.
+# Pass real values with --set-string or an unversioned values file; never
+# commit them here.
+secrets: {}
+# API_TOKEN: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+# The chart creates its own namespace, named after the chart. Set this to
+# deploy into an existing one instead -- note the Namespace resource is still
+# rendered, so point it at a namespace this release is allowed to own.
+namespaceOverride: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsUser: 30000
+  runAsGroup: 30000
+  fsGroup: 30000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  privileged: false
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ exclude = [
     ".vscode/**",
     "Dockerfile",
     "Makefile",
+    "charts/**",
     "renovate.json",
     "scripts/**",
     "tests/**",

--- a/scripts/functions.bash
+++ b/scripts/functions.bash
@@ -24,6 +24,20 @@ get_tag_at_head() {
     echo "${TAG#v}"
 }
 
+# Locates the single Helm chart under 'charts/'
+# Discovered rather than hard-coded, so renaming the chart when you claim this
+# template as your own does not mean editing the scripts too.
+get_chart_dir() {
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    charts=("$dir"/../charts/*/)
+    if [ "${#charts[@]}" -ne 1 ] || [ ! -f "${charts[0]}Chart.yaml" ]; then
+        echo "Expected exactly one chart under charts/, found ${#charts[@]}" >&2
+        return 1
+    fi
+    # Trim the trailing slash
+    echo "${charts[0]%/}"
+}
+
 # Extracts the project name as configured in 'pyproject.toml'
 # '--no-project' keeps this usable before the environment has been synced.
 get_project_name() {

--- a/scripts/helm-set-version.bash
+++ b/scripts/helm-set-version.bash
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -ueo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly DIR
+
+# shellcheck disable=SC1091
+source "$DIR/functions.bash"
+
+CHART_DIR="$(get_chart_dir)"
+readonly CHART_DIR
+
+# Helm chart versions are SemVer *without* a leading 'v', while git tags here
+# carry one (v0.1.0). get_tag_at_head already strips it; the second strip
+# holds that invariant if the helper is ever swapped for one that does not.
+# Getting this wrong publishes template-python-package-v0.1.0.tgz, which
+# breaks the naming convention of every chart already in the index.
+VERSION="$(get_tag_at_head)"
+VERSION="${VERSION#v}"
+
+if [ -z "$VERSION" ]; then
+    echo "No version tag found at HEAD, cannot set the chart version..." >&2
+    exit 1
+fi
+readonly VERSION
+
+sed -i.bak \
+    -e "s/^version: .*/version: \"$VERSION\"/" \
+    -e "s/^appVersion: .*/appVersion: \"$VERSION\"/" \
+    "$CHART_DIR/Chart.yaml"
+rm -f "$CHART_DIR/Chart.yaml.bak"
+
+echo "Updated Helm chart version to $VERSION" >&2


### PR DESCRIPTION
Closes #15.

Ports the chart layout from [waf-downloader](https://github.com/MihaiBojin/waf-downloader), genericized for the demo CLI, with the three failures fixed in [waf-downloader#176](https://github.com/MihaiBojin/waf-downloader/pull/176) designed in rather than repeated.

## The bug class this avoids

waf-downloader's chart release was green and doing nothing for seven releases. Three things caused it, and all three are handled here:

**1. Invisible version bump.** There, `Chart.yaml` is generated from `Chart.yaml.tmpl` and gitignored. chart-releaser decides what to publish by diffing *tracked* files under `charts/`, so the bump was invisible and the release was skipped in silence.

Here `Chart.yaml` is **tracked**, at a `0.0.0` placeholder mirroring the `VERSION` file. That also means `helm lint` works on a fresh clone with no generator step. The workflow still commits the rewritten version locally before invoking chart-releaser — the tracked placeholder is identical between tags, so the diff would otherwise still be empty. The commit never leaves the runner.

**2. The `v` prefix.** Helm chart versions are SemVer without one; artifacts are named `template-python-package-0.1.0.tgz`. `get_tag_at_head` already strips it here, so the second strip in `helm-set-version.bash` is holding an invariant rather than fixing a live bug — but it is the invariant that broke there.

**3. Silent no-op.** chart-releaser exits 0 when it finds nothing to do. The workflow fails explicitly if `changed_charts` is empty on a tag build.

## Two deliberate departures from the source chart

- **The test pod runs the application image and asserts a clean exit**, instead of shelling out to `kubectl` to check the Deployment's pod is Running. The original does the latter from a `busybox` image, which has no `kubectl`, and would need RBAC to list pods even if it did. A test that cannot pass is worse than no test.
- **No `required.yaml`.** Requiring values means the chart cannot lint or render out of the box, which is the wrong default for something people copy.

## What is in the chart

Namespace, ConfigMap, Secret, Deployment, `_helpers.tpl` and a test pod. `config` and `secrets` are free-form maps — every key becomes an environment variable via `envFrom` — and the Deployment carries checksum annotations so `helm upgrade` actually rolls the pods when either changes.

The default workload restarts forever, because the demo CLI prints one line and exits. That is called out in the chart README rather than papered over: it proves the image is wired up without pretending to be a real service.

## Supporting changes

- `get_chart_dir` globs `charts/*`, so renaming the chart does not mean editing the scripts.
- `check-yaml` skips `charts/*/templates/` — Go templates are not YAML until rendered. `Chart.yaml` and `values.yaml` are still checked; `make helm-lint` covers the templates.
- **`out/` added to `.gitignore`.** `make helm-package` writes there, and an untracked `out/` would make `is_dirty` report dirty, which hard-fails `detect-and-set-tag-version.bash`. Latent until something finally wrote to the directory `make clean` has always removed.
- `charts/**` excluded from the sdist and the docker build context.
- `make helm-lint`, `helm-package`, `helm-set-version`.

## Still switched off

Like the PyPI flow, the `publish` job is behind `if: false`, because it needs a `gh-pages` branch and Pages serving from it — neither of which can be done from a commit. The README documents both steps and the enabling line. The `lint` job runs on every tag regardless.

## Verification

- `helm lint` and `helm template` pass; rendering checked against default values and with `secrets`, `args`, `image.tag` and `namespaceOverride` overridden
- Confirmed no stray `#` comments leak into rendered manifests (an earlier draft did)
- `helm-set-version.bash` driven with a throwaway `v9.9.9-test` tag: `Chart.yaml` updated, chart label correct, packaged as `template-python-package-9.9.9-test.tgz` — no `v`
- **Change detection simulated end to end** in a throwaway clone. With the local version commit, `git diff <prev-chart-tag> HEAD -- charts/` lists `Chart.yaml` and chart-releaser fires. Without it, the diff is empty and the release would be silently skipped — the exact waf-downloader failure, now caught by the verify step either way
- `actionlint` clean apart from the intentional `if: false`
- Verified `azure/setup-helm@v5.0.1` and `helm/chart-releaser-action@v1.7.0` both resolve and are the current releases
- Confirmed the `check-yaml` exclude is not over-broad by deliberately breaking `values.yaml` and watching it fail
- Full `scripts/pre-push.bash` green: 12 hooks, tests, build, docker

`helm lint` emits one INFO, `icon is recommended`. Left alone — inventing an icon for a template is not my call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)